### PR TITLE
feat: add cache key github

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ npm install -g standard-monorepo
 $ standard-monorepo COMMAND
 running command...
 $ standard-monorepo (-v|--version|version)
-standard-monorepo/0.5.2 darwin-x64 node-v14.15.1
+standard-monorepo/0.6.0 darwin-x64 node-v14.15.1
 $ standard-monorepo --help [COMMAND]
 USAGE
   $ standard-monorepo COMMAND
@@ -105,13 +105,34 @@ USAGE
 
 OPTIONS
   -h, --help  show CLI help
-  --cwd       context should be from where the command was run
+  --cwd       use the context from where the command was run to determine root of the monorepo
+  --github    print github actions output
 
-EXAMPLE
+EXAMPLES
   $ standard-monorepo cache-key # 93ead503b3bc9b08c2e07da10ef34162
+  $ standard-monorepo cache-key --cwd # 93ead503b3bc9b08c2e07da10ef34162
+  $ standard-monorepo cache-key --github # ::set-output name=cacheKey::{env.PREFIX}-93ead503b3bc9b08c2e07da10ef34162
+  - name: Get nodemodules cache key
+           id: cache-key
+           shell: bash
+           run: npx standard-monorepo cache-key
+           env:
+             PREFIX: ubuntu-latest-node-14.16.0
+          
+         - name: Cache node modules
+           id: cache-node-modules
+           uses: actions/cache@v2
+           env:
+             cache-name: cache-node-modules
+           with:
+             path: |
+               node_modules
+               **/node_modules
+             key: steps.cache-key.outputs.cacheKey
+             restore-keys: steps.cache-key.outputs.cacheKey
 ```
 
-_See code: [src/commands/cache-key.ts](https://github.com/imflavio/standard-monorepo/blob/v0.5.2/src/commands/cache-key.ts)_
+_See code: [src/commands/cache-key.ts](https://github.com/imflavio/standard-monorepo/blob/v0.6.0/src/commands/cache-key.ts)_
 
 ## `standard-monorepo circular-deps`
 
@@ -129,7 +150,7 @@ EXAMPLES
   $ standard-monorepo circular-deps --max=5 --max-total-paths=10 # default is 0 for both
 ```
 
-_See code: [src/commands/circular-deps.ts](https://github.com/imflavio/standard-monorepo/blob/v0.5.2/src/commands/circular-deps.ts)_
+_See code: [src/commands/circular-deps.ts](https://github.com/imflavio/standard-monorepo/blob/v0.6.0/src/commands/circular-deps.ts)_
 
 ## `standard-monorepo commit [COMMIT]`
 
@@ -158,7 +179,7 @@ EXAMPLES
   }
 ```
 
-_See code: [src/commands/commit.ts](https://github.com/imflavio/standard-monorepo/blob/v0.5.2/src/commands/commit.ts)_
+_See code: [src/commands/commit.ts](https://github.com/imflavio/standard-monorepo/blob/v0.6.0/src/commands/commit.ts)_
 
 ## `standard-monorepo help [COMMAND]`
 
@@ -220,5 +241,5 @@ EXAMPLES
   $ standard-monorepo list --since=main # same as above as --fork-point default is true
 ```
 
-_See code: [src/commands/list.ts](https://github.com/imflavio/standard-monorepo/blob/v0.5.2/src/commands/list.ts)_
+_See code: [src/commands/list.ts](https://github.com/imflavio/standard-monorepo/blob/v0.6.0/src/commands/list.ts)_
 <!-- commandsstop -->


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.6.1-canary.35.f020c8c.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install standard-monorepo@0.6.1-canary.35.f020c8c.0
  # or 
  yarn add standard-monorepo@0.6.1-canary.35.f020c8c.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
